### PR TITLE
only convert images from screenshots to base64

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -24,13 +24,23 @@
         var editor = event.listenerData && event.listenerData.editor;
         var $event = event.data.$;
         var clipboardData = $event.clipboardData;
-        var found = false;
+        // var found = false;
         var imageType = /^image/;
 
         if (!clipboardData) {
             return;
         }
 
+        // clipboardData may contain different content regarding where you copied the image from.
+        // We're trying to convert only images from screenshots to base64, because otherwise you may
+        // encounter a double paste.
+        // clipboardData from screenshots appear to match the following structure on Ubuntu Linux,
+        // Windows and Mac OS X
+        if (clipboardData.items.length === 1 && clipboardData.items[0].type.match(imageType)) {
+            readImageAsBase64(clipboardData.items[0], editor);
+        }
+
+        /*
         return Array.prototype.forEach.call(clipboardData.types, function (type, i) {
             if (found) {
                 return;
@@ -41,6 +51,7 @@
                 return found = true;
             }
         });
+        */
     }
 
     function readImageAsBase64(item, editor) {


### PR DESCRIPTION
This change resolves double paste when pasting pictures from web.
I try to limit converting to base64 to system screenshots only.

Tested on Ubuntu 16.04, Windows 10 and Mac OS X with the following situations:
- [x] copy image on web (pasted image, not converted to base64)
- [x] take a snapshot and copy to clipboard (pasted as base64)
- [ ] copy an image file from the system's file browser (not pasted as image. the clipboard data turns out different on three OS's)